### PR TITLE
Fix the build on linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ quality drops.
 
 Illumina reads often have poor 3'-end qualities. I've noticed that
 HiSeq machines also produce poor quality 5'-ends. For increased
-mapping rates and better assmeblies, it is generally advisable that
+mapping rates and better assemblies, it is generally advisable that
 these poor quality regions be trimmed off. Nik Joshi's took `sickle`
 tool can do this; you can get it here
 <http://github.com/najoshi/sickle>.

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,5 +1,5 @@
 RHTSLIB_LIBS=`echo 'Rhtslib::pkgconfig("PKG_LIBS")'|\
-    "${R_HOME}/bin/R" --vanilla --slave | tr -d "'"`
+    "${R_HOME}/bin/R" --vanilla --slave | tr ' "`
 RHTSLIB_CPPFLAGS=`echo 'Rhtslib::pkgconfig("PKG_CPPFLAGS")'|\
     "${R_HOME}/bin/R" --vanilla --slave`
 

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,5 +1,5 @@
 RHTSLIB_LIBS=`echo 'Rhtslib::pkgconfig("PKG_LIBS")'|\
-    "${R_HOME}/bin/R" --vanilla --slave`
+    "${R_HOME}/bin/R" --vanilla --slave | tr -d "'"`
 RHTSLIB_CPPFLAGS=`echo 'Rhtslib::pkgconfig("PKG_CPPFLAGS")'|\
     "${R_HOME}/bin/R" --vanilla --slave`
 

--- a/src/io.c
+++ b/src/io.c
@@ -219,7 +219,7 @@ static void hash_seq_kmers(int k, khash_t(str) *h, kseq_t *block, unsigned int *
      bytes to hold the k-mers, not including hashing overhead.
 
   */
-  char *a_kmer = Calloc(k + 2 + log10(SINT_MAX), char), *start_ptr;
+  char *a_kmer = Calloc(k + 2 + log10(INT8_MAX), char), *start_ptr;
   int i;
   khiter_t key;
   int is_missing, ret;

--- a/src/io.c
+++ b/src/io.c
@@ -219,7 +219,7 @@ static void hash_seq_kmers(int k, khash_t(str) *h, kseq_t *block, unsigned int *
      bytes to hold the k-mers, not including hashing overhead.
 
   */
-  char *a_kmer = Calloc(k + 2 + log10(INT8_MAX), char), *start_ptr;
+  char *a_kmer = Calloc(k + 2 + log10(INT_MAX), char), *start_ptr;
   int i;
   khiter_t key;
   int is_missing, ret;


### PR DESCRIPTION
Fixes #9 

1. Replace SINT_MAX (from R.h ?!) with INT8_MAX (from stdint.h)
    
2. Pass the result of Rhtslib::pkgconfig("PKG_LIBS") to `tr -d "'"`
    
    because it returns it wrapped in single quotes and the linker (ld)
    cannot file the file:
    
    `/usr/bin/ld: cannot find '/home/biocbuild/bbs-3.17-bioc/R/library/Rhtslib/usrlib/libhts.a': No such file or directory`
    
 3. Fix a minor typo
    
